### PR TITLE
Prevent toolbar links color override by css

### DIFF
--- a/Resources/views/Profiler/toolbar.css.twig
+++ b/Resources/views/Profiler/toolbar.css.twig
@@ -63,6 +63,9 @@
     -webkit-font-smoothing: subpixel-antialiased;
     -moz-osx-font-smoothing: auto;
 }
+div.sf-toolbar .sf-toolbarreset a {
+    color: #99CDD8;
+}
 .sf-toolbarreset abbr {
     border: dashed #777;
     border-width: 0 0 1px;


### PR DESCRIPTION
Fixes this issue: https://github.com/symfony/symfony/issues/27658#issuecomment-401008659

Links color in toolbar can be easily override.

As this could happens sometimes, this PR set links color with a stronger CSS precedence.